### PR TITLE
fix ScriptUI

### DIFF
--- a/shared/ScriptUI.d.ts
+++ b/shared/ScriptUI.d.ts
@@ -1184,8 +1184,9 @@ declare class ListBox extends _Control {
    * Returns the item control object. If this is a multi-column list box, each added ListItem represents one selectable row.Its text and image values specify the label in the first column, and the subitems property specifies the labels in the additional columns.
    * @param type The type of the child element, the string "item".
    * @param text The localizable text label for the item.
+   * @param index The index into the current item list after which this item is inserted. If not supplied, or greater than the current list length, the new item is added at the end.
    */
-  add(type: string, text?: string): ListItem
+  add(type: "item", text?: string, index?: number): ListItem
 
   /**
    * Retrieves an item object from the list that has a given text label.
@@ -1295,8 +1296,10 @@ declare class DropDownList extends _Control {
    * Returns the item control object for type="item", or null for type="separator".
    * @param type The type of the child element. Either item (a basic, selectable item with a text label) or separator
    * @param text The localizable text label for the item.
+   * @param index The index into the current item list after which this item is inserted. If not supplied, or greater than the current list length, the new item is added at the end.
    */
-  add(type: string, text?: string): ListItem
+  add(type: "item", text?: string, index?: number): ListItem
+  add(type: "separator", text?: string, index?: number): null
 
   /**
    * Retrieves an item object from the list that has a given text label.
@@ -1409,6 +1412,15 @@ declare class ListItem {
    * Normally "item", but an item whose parent is a DropDownList control can have type "separator". A separator item is not mouse-sensitive and is drawn as a horizontal line across the drop-down or pop-up menu.
    */
   readonly type: string
+
+  /**
+   * Adds an item to the choices in this list.
+   * Returns the item control object.
+   * @param type The type of the child element, the string "item" or "node".
+   * @param text The localizable text label for the item.
+   * @param index The index into the current item list after which this item is inserted. If not supplied, or greater than the current list length, the new item is added at the end.
+   */
+  add(type: "item" | "node", text?: string, index?: number): ListItem
 }
 
 /**
@@ -1847,10 +1859,11 @@ declare class TreeView extends _Control {
   /**
    * Adds an item to the top-level choices in this list.
    * Returns the item control object.
-   * @param type The type of the child element, the string "item".
+   * @param type The type of the child element, the string "item" or "node".
    * @param text The localizable text label for the item.
+   * @param index The index into the current item list after which this item is inserted. If not supplied, or greater than the current list length, the new item is added at the end.
    */
-  add(type: string, text?: string): ListItem
+  add(type: "item" | "node", text?: string, index?: number): ListItem
 
   /**
    * Retrieves an item object from the list that has a given text label.

--- a/shared/ScriptUI.d.ts
+++ b/shared/ScriptUI.d.ts
@@ -944,6 +944,9 @@ declare class IconButton extends _Control {
    */
   shortcutKey: string
 
+  title: string
+  titleLayout: _TitleLayout
+
   /**
    * Sends a notification message, simulating the specified user interaction event.
    * @param eventName The name of the control event handler to call. One of: onClick, onChange, onChanging. By default, simulates the onChange event for an edittext control, an onClick event for controls that support that event.
@@ -1009,6 +1012,9 @@ declare class Image extends _Control {
    * The key sequence that invokes the onShortcutKey() callback for this element (in Windows only).
    */
   shortcutKey: string
+
+  title: string
+  titleLayout: _TitleLayout
 
   /**
    * An event-handler callback function, called when the element acquires the keyboard focus.
@@ -1292,6 +1298,9 @@ declare class DropDownList extends _Control {
    * The key sequence that invokes the onShortcutKey() callback for this element (in Windows only).
    */
   shortcutKey: string
+
+  title: string
+  titleLayout: _TitleLayout
 
   /**
    * Adds an item or separator to the choices in this list.
@@ -1943,6 +1952,9 @@ declare class FlashPlayer extends _Control {
    */
   active: boolean
 
+  title: string
+  titleLayout: _TitleLayout
+
   /**
    * A function definition for a callback from the Flash ActionScript environment.
    * The Flash ActionScript code can call any callback function defined on the ExtendScript side of the FlashPlayer object, invoking it by name as a property of the control object. The function can take any arguments of a supported data types, and can return any value of a supported data type. data types:Number, String, Boolean, null, undefined, Object, Array.
@@ -2166,6 +2178,9 @@ declare class TabbedPanel extends Panel {
    * When the value of the selection property changes, either by a user selecting a different tab, or by a script setting the property, the TabbedPanel receives an onChange notification.
    */
   selection: Tab | number
+
+  title: string
+  titleLayout: _TitleLayout
 
   /**
    * An event-handler callback function, called when the selected tab has changed.
@@ -2961,4 +2976,13 @@ interface _AddControl {
     items?: string[],
     properties?: _AddControlPropertiesTreeView,
   ): TreeView
+}
+
+interface _TitleLayout {
+  alignment?: _Alignment
+  characters?: number
+  spacing?: number
+  margins?: [number, number, number, number]
+  justify?: _Justify
+  truncate?: _Truncate
 }

--- a/shared/ScriptUI.d.ts
+++ b/shared/ScriptUI.d.ts
@@ -195,7 +195,7 @@ declare class Window extends _Control {
    * The layout manager for this container.
    * The first time a container object is made visible, ScriptUI invokes this layout manager by calling its layout() function. Default is an instance of the LayoutManager class that is automatically created when the container element is created.
    */
-  layout: LayoutManager
+  layout: AutoLayoutManager
 
   /**
    * The number of pixels between the edges of a container and the outermost child elements.
@@ -386,7 +386,7 @@ declare class Window extends _Control {
  * Controls the automatic layout behavior for a window or container.
  * The subclass AutoLayoutManager implements the default automatic layout behavior.
  */
-declare class LayoutManager {
+declare class AutoLayoutManager {
   /**
    * Invokes the automatic layout behavior for the managed container.
    * Adjusts sizes and positions of the child elements of this window or container according to the placement and alignment property values in the parent and children.
@@ -1993,7 +1993,7 @@ declare class Group extends _Control {
    * The layout manager for this container.
    * The first time a container object is made visible, ScriptUI invokes this layout manager by calling its layout() function. Default is an instance of the LayoutManager class that is automatically created when the container element is created.
    */
-  layout: LayoutManager
+  layout: AutoLayoutManager
 
   /**
    * The number of pixels between the edges of a container and the outermost child elements.
@@ -2072,7 +2072,7 @@ declare class Panel extends _Control {
    * The layout manager for this container.
    * The first time a container object is made visible, ScriptUI invokes this layout manager by calling its layout() function. Default is an instance of the LayoutManager class that is automatically created when the container element is created.
    */
-  layout: LayoutManager
+  layout: AutoLayoutManager
 
   /**
    * The number of pixels between the edges of a container and the outermost child elements.

--- a/shared/ScriptUI.d.ts
+++ b/shared/ScriptUI.d.ts
@@ -28,6 +28,8 @@ type _AlignmentProperty = "left" | "right" | "fill" | "center"
   | ["left" | "right" | "fill" | "center", "top" | "bottom" | "fill" | "center"]
   | [_Alignment.LEFT | _Alignment.RIGHT | _Alignment.FILL | _Alignment.CENTER, _Alignment.TOP | _Alignment.BOTTOM | _Alignment.FILL | _Alignment.CENTER];
 
+type _Justify = "left" | "center" | "right";
+
 /**
  * A global class containing central information about ScriptUI. Not instantiable.
  */
@@ -185,7 +187,7 @@ declare class Window extends _Control {
    * The default text justification style for child text elements.
    * One of left, center, or right. Justification only works if this value is set on creation of the element.
    */
-  justify: string
+  justify: _Justify
 
   /**
    * The layout manager for this container.
@@ -792,7 +794,7 @@ declare class StaticText extends _Control {
    * The text justification style.
    * One of left, center, or right. Justification only works if this value is set on creation of the element.
    */
-  justify: string
+  justify: _Justify
 
   /**
    * The key sequence that invokes the onShortcutKey() callback for this element (in Windows only).
@@ -853,7 +855,7 @@ declare class Button extends _Control {
    * The text justification style.
    * One of left, center, or right. Justification only works if this value is set on creation of the element.
    */
-  justify: string
+  justify: _Justify
 
   /**
    * The key sequence that invokes the onShortcutKey() callback for this element (in Windows only).
@@ -1059,7 +1061,7 @@ declare class EditText extends _Control {
    * The text justification style.
    * One of left, center, or right. Justification only works if this value is set on creation of the element.
    */
-  justify: string
+  justify: _Justify
 
   /**
    * The key sequence that invokes the onShortcutKey() callback for this element (in Windows only).
@@ -1437,7 +1439,7 @@ declare class Checkbox extends _Control {
    * The default text justification style for child text elements.
    * One of left, center, or right. Justification only works if this value is set on creation of the element.
    */
-  justify: string
+  justify: _Justify
 
   /**
    * The key sequence that invokes the onShortcutKey() callback for this element (in Windows only).
@@ -1619,7 +1621,7 @@ declare class RadioButton extends _Control {
    * The default text justification style for child text elements.
    * One of left, center, or right. Justification only works if this value is set on creation of the element.
    */
-  justify: string
+  justify: _Justify
 
   /**
    * The key sequence that invokes the onShortcutKey() callback for this element (in Windows only).
@@ -2062,7 +2064,7 @@ declare class Panel extends _Control {
    * The default text justification style for child text elements.
    * One of left, center, or right. Justification only works if this value is set on creation of the element.
    */
-  justify: string
+  justify: _Justify
 
   /**
    * The layout manager for this container.

--- a/shared/ScriptUI.d.ts
+++ b/shared/ScriptUI.d.ts
@@ -32,6 +32,8 @@ type _Justify = "left" | "center" | "right"
 
 type _Orientation = "row" | "column" | "stack"
 
+type _Truncate = "middle" | "end" | "none"
+
 /**
  * A global class containing central information about ScriptUI. Not instantiable.
  */
@@ -2776,7 +2778,7 @@ interface _AddControlPropertiesStaticText {
   name?: string
   multiline?: boolean
   scrolling?: boolean
-  truncate?: string
+  truncate?: _Truncate
 }
 
 /**

--- a/shared/ScriptUI.d.ts
+++ b/shared/ScriptUI.d.ts
@@ -2531,6 +2531,27 @@ declare class KeyboardState {
   readonly shiftKey: boolean
 }
 
+declare class KeyboardEvent extends UIEvent implements KeyboardState {
+  altKey: boolean;
+  ctrlKey: boolean;
+  metaKey: boolean;
+  shiftKey: boolean;
+  keyIdentifier: string;
+  keyLocation: number;
+  keyName: string;
+  type: string;
+  getModifierState(keyIdentifier: "Alt" | "CapsLock" | "Control" | "Meta" | "NumLock" | "Scroll" | "Shift"): boolean
+  initKeyboardEvent(
+    eventName: string,
+    bubble: boolean,
+    isCancelable: boolean,
+    view: _Control,
+    keyID: string,
+    keyLocation: number,
+    modifiersList: string,
+  ): void
+}
+
 /**
  * A Control class.
  */

--- a/shared/ScriptUI.d.ts
+++ b/shared/ScriptUI.d.ts
@@ -2,11 +2,11 @@
 
 declare enum _Alignment {
   TOP = 1,
-  BOTTOM,
-  LEFT,
-  RIGHT,
-  FILL,
-  CENTER,
+  BOTTOM = 2,
+  LEFT = 3,
+  RIGHT = 4,
+  FILL = 5,
+  CENTER = 6,
 }
 
 declare enum _FontStyle {
@@ -22,6 +22,11 @@ declare const enum _BrushOrPenType {
 }
 
 type _Bounds = Bounds | [number, number, number, number]
+
+type _AlignmentProperty = "left" | "right" | "fill" | "center"
+  | "top" | "bottom" | "fill" | "center"
+  | ["left" | "right" | "fill" | "center", "top" | "bottom" | "fill" | "center"]
+  | [_Alignment.LEFT | _Alignment.RIGHT | _Alignment.FILL | _Alignment.CENTER, _Alignment.TOP | _Alignment.BOTTOM | _Alignment.FILL | _Alignment.CENTER];
 
 /**
  * A global class containing central information about ScriptUI. Not instantiable.
@@ -124,7 +129,7 @@ declare class Window extends _Control {
    * Tells the layout manager how unlike-sized children of this container should be aligned within a column or row.
    * Order of creation determines which children are at the top of a column or the left of a row; the earlier a child is created, the closer it is to the top or left of its column or row. If defined, alignment for a child element overrides the alignChildren setting for the parent container. See alignment property for values.
    */
-  alignChildren: string
+  alignChildren: _AlignmentProperty
 
   /**
    * For windows of type dialog, the UI element to notify when the user presses a cancellation key combination.
@@ -1968,7 +1973,7 @@ declare class Group extends _Control {
    * Tells the layout manager how unlike-sized children of this container should be aligned within a column or row.
    * Order of creation determines which children are at the top of a column or the left of a row; the earlier a child is created, the closer it is to the top or left of its column or row. If defined, alignment for a child element overrides the alignChildren setting for the parent container. See alignment property for values.
    */
-  alignChildren: string
+  alignChildren: _AlignmentProperty
 
   /**
    * An array of child elements.
@@ -2036,7 +2041,7 @@ declare class Panel extends _Control {
   /**
    * Specifies how to align the child elements.
    */
-  alignChildren: string
+  alignChildren: _AlignmentProperty
 
   /**
    * Reserve space for the specified number of characters; affects calculation of preferredSize .
@@ -2520,7 +2525,7 @@ declare class _Control {
    * For orientation = column: left, right, fill
    * For orientation = stack: top, bottom, left, right, fill
    */
-  alignment: string
+  alignment: _AlignmentProperty
 
   /**
    * The boundaries of the element, in parent-relative coordinates.

--- a/shared/ScriptUI.d.ts
+++ b/shared/ScriptUI.d.ts
@@ -255,7 +255,7 @@ declare class Window extends _Control {
    * @param properties An object containing creation-only properties.
    */
   constructor(
-    type: string,
+    type: "dialog" | "palette" | "window",
     title?: string,
     bounds?: _Bounds,
     properties?: _AddControlPropertiesWindow,

--- a/shared/ScriptUI.d.ts
+++ b/shared/ScriptUI.d.ts
@@ -26,9 +26,11 @@ type _Bounds = Bounds | [number, number, number, number]
 type _AlignmentProperty = "left" | "right" | "fill" | "center"
   | "top" | "bottom" | "fill" | "center"
   | ["left" | "right" | "fill" | "center", "top" | "bottom" | "fill" | "center"]
-  | [_Alignment.LEFT | _Alignment.RIGHT | _Alignment.FILL | _Alignment.CENTER, _Alignment.TOP | _Alignment.BOTTOM | _Alignment.FILL | _Alignment.CENTER];
+  | [_Alignment.LEFT | _Alignment.RIGHT | _Alignment.FILL | _Alignment.CENTER, _Alignment.TOP | _Alignment.BOTTOM | _Alignment.FILL | _Alignment.CENTER]
 
-type _Justify = "left" | "center" | "right";
+type _Justify = "left" | "center" | "right"
+
+type _Orientation = "row" | "column" | "stack"
 
 /**
  * A global class containing central information about ScriptUI. Not instantiable.
@@ -221,7 +223,7 @@ declare class Window extends _Control {
    * The layout orientation of children in a container.
    * Interpreted by the layout manager for the container. The default LayoutManager  Object accepts the (case-insensitive) values row, column, or stack.For window and panel, the default is column, and for group the default is row. The allowed values for the container’s alignChildren and its children’s alignment properties depend on the orientation.
    */
-  orientation: string
+  orientation: _Orientation
 
   /**
    * The keypress combination that invokes this element's onShortcutKey() callback.
@@ -2003,7 +2005,7 @@ declare class Group extends _Control {
    * The layout orientation of children in a container.
    * Interpreted by the layout manager for the container. The default LayoutManager  Object accepts the (case-insensitive) values row, column, or stack.For window and panel, the default is column, and for group the default is row. The allowed values for the container’s alignChildren and its children’s alignment properties depend on the orientation.
    */
-  orientation: string
+  orientation: _Orientation
 
   /**
    * The number of pixels separating one child element from its adjacent sibling element.
@@ -2082,7 +2084,7 @@ declare class Panel extends _Control {
    * The layout orientation of children in a container.
    * Interpreted by the layout manager for the container. The default LayoutManager  Object accepts the (case-insensitive) values row, column, or stack.For window and panel, the default is column, and for group the default is row. The allowed values for the container’s alignChildren and its children’s alignment properties depend on the orientation.
    */
-  orientation: string
+  orientation: _Orientation
 
   /**
    * The number of pixels separating one child element from its adjacent sibling element.


### PR DESCRIPTION
1. fix alignment and alignChildren properties
Declared _AlignmentProperty type.
Changed alignment and alignChildren types from string to _AlignmentProperty.
2. fix justify property
Declared _Justify type.
Changed justify type from string to _Justify.
3. fix justify property
Declared _Orientation type.
Changed orientation type from string to _Orientation.
4. fix AutoLayoutManager class
Changed LayoutManager class into AutoLayoutManager class.
5. fix Window.constructor
Changed type of type property from string to "dialog" | "palette" | "window".
6. fix list control objects
Fixed "add" function of ListItem, ListBox, DropDownList and TreeView.
7. declare KeyboardEvent class
8. fix truncate property
Declared _Truncate type.
Changed truncate type from string to _Truncate.
9. add title and titleLayout properties
Declared _TitleLayout type.
Added title and titleLayout properties.