### PR TITLE
Fix some AE layer type errors

### DIFF
--- a/AfterEffects/10.5/index.d.ts
+++ b/AfterEffects/10.5/index.d.ts
@@ -1293,12 +1293,12 @@ declare class Layer extends PropertyGroup {
   readonly transform: _TransformGroup
 
   /** Transform shortcuts */
-  readonly anchorPoint: TwoDProperty | ThreeDProperty
-  readonly position: TwoDProperty | ThreeDProperty
+  readonly anchorPoint: Property<TwoDType | ThreeDType>
+  readonly position: Property<TwoDType | ThreeDType>
   readonly xPosition: OneDProperty
   readonly yPosition: OneDProperty
   readonly zPosition: OneDProperty
-  readonly scale: TwoDProperty | ThreeDProperty
+  readonly scale: Property<TwoDType | ThreeDType>
   readonly orientation: ThreeDProperty
   readonly rotation: OneDProperty
   readonly xRotation: OneDProperty
@@ -2176,12 +2176,12 @@ declare class TextLayer extends AVLayer {
  * Properties for Shortcuts
  */
 declare interface _TransformGroup extends PropertyGroup {
-  readonly anchorPoint: TwoDProperty | ThreeDProperty
-  readonly position: TwoDProperty | ThreeDProperty
+  readonly anchorPoint: Property<TwoDType | ThreeDType>
+  readonly position: Property<TwoDType | ThreeDType>
   readonly xPosition: OneDProperty
   readonly yPosition: OneDProperty
   readonly zPosition: OneDProperty
-  readonly scale: TwoDProperty | ThreeDProperty
+  readonly scale: Property<TwoDType | ThreeDType>
   readonly orientation: ThreeDProperty
   readonly rotation: OneDProperty
   readonly xRotation: OneDProperty

--- a/AfterEffects/11.0/index.d.ts
+++ b/AfterEffects/11.0/index.d.ts
@@ -1329,12 +1329,12 @@ declare class Layer extends PropertyGroup {
   readonly transform: _TransformGroup
 
   /** Transform shortcuts */
-  readonly anchorPoint: TwoDProperty | ThreeDProperty
-  readonly position: TwoDProperty | ThreeDProperty
+  readonly anchorPoint: Property<TwoDType | ThreeDType>
+  readonly position: Property<TwoDType | ThreeDType>
   readonly xPosition: OneDProperty
   readonly yPosition: OneDProperty
   readonly zPosition: OneDProperty
-  readonly scale: TwoDProperty | ThreeDProperty
+  readonly scale: Property<TwoDType | ThreeDType>
   readonly orientation: ThreeDProperty
   readonly rotation: OneDProperty
   readonly xRotation: OneDProperty
@@ -2272,12 +2272,12 @@ declare class ViewOptions {
  * Properties for Shortcuts
  */
 declare interface _TransformGroup extends PropertyGroup {
-  readonly anchorPoint: TwoDProperty | ThreeDProperty
-  readonly position: TwoDProperty | ThreeDProperty
+  readonly anchorPoint: Property<TwoDType | ThreeDType>
+  readonly position: Property<TwoDType | ThreeDType>
   readonly xPosition: OneDProperty
   readonly yPosition: OneDProperty
   readonly zPosition: OneDProperty
-  readonly scale: TwoDProperty | ThreeDProperty
+  readonly scale: Property<TwoDType | ThreeDType>
   readonly orientation: ThreeDProperty
   readonly rotation: OneDProperty
   readonly xRotation: OneDProperty

--- a/AfterEffects/12.0/index.d.ts
+++ b/AfterEffects/12.0/index.d.ts
@@ -1349,12 +1349,12 @@ declare class Layer extends PropertyGroup {
   readonly transform: _TransformGroup
 
   /** Transform shortcuts */
-  readonly anchorPoint: TwoDProperty | ThreeDProperty
-  readonly position: TwoDProperty | ThreeDProperty
+  readonly anchorPoint: Property<TwoDType | ThreeDType>
+  readonly position: Property<TwoDType | ThreeDType>
   readonly xPosition: OneDProperty
   readonly yPosition: OneDProperty
   readonly zPosition: OneDProperty
-  readonly scale: TwoDProperty | ThreeDProperty
+  readonly scale: Property<TwoDType | ThreeDType>
   readonly orientation: ThreeDProperty
   readonly rotation: OneDProperty
   readonly xRotation: OneDProperty
@@ -2293,12 +2293,12 @@ declare class ViewOptions {
  * Properties for Shortcuts
  */
 declare interface _TransformGroup extends PropertyGroup {
-  readonly anchorPoint: TwoDProperty | ThreeDProperty
-  readonly position: TwoDProperty | ThreeDProperty
+  readonly anchorPoint: Property<TwoDType | ThreeDType>
+  readonly position: Property<TwoDType | ThreeDType>
   readonly xPosition: OneDProperty
   readonly yPosition: OneDProperty
   readonly zPosition: OneDProperty
-  readonly scale: TwoDProperty | ThreeDProperty
+  readonly scale: Property<TwoDType | ThreeDType>
   readonly orientation: ThreeDProperty
   readonly rotation: OneDProperty
   readonly xRotation: OneDProperty

--- a/AfterEffects/13.0/index.d.ts
+++ b/AfterEffects/13.0/index.d.ts
@@ -1358,12 +1358,12 @@ declare class Layer extends PropertyGroup {
   readonly transform: _TransformGroup
 
   /** Transform shortcuts */
-  readonly anchorPoint: TwoDProperty | ThreeDProperty
-  readonly position: TwoDProperty | ThreeDProperty
+  readonly anchorPoint: Property<TwoDType | ThreeDType>
+  readonly position: Property<TwoDType | ThreeDType>
   readonly xPosition: OneDProperty
   readonly yPosition: OneDProperty
   readonly zPosition: OneDProperty
-  readonly scale: TwoDProperty | ThreeDProperty
+  readonly scale: Property<TwoDType | ThreeDType>
   readonly orientation: ThreeDProperty
   readonly rotation: OneDProperty
   readonly xRotation: OneDProperty
@@ -2347,12 +2347,12 @@ declare class ViewOptions {
  * Properties for Shortcuts
  */
 declare interface _TransformGroup extends PropertyGroup {
-  readonly anchorPoint: TwoDProperty | ThreeDProperty
-  readonly position: TwoDProperty | ThreeDProperty
+  readonly anchorPoint: Property<TwoDType | ThreeDType>
+  readonly position: Property<TwoDType | ThreeDType>
   readonly xPosition: OneDProperty
   readonly yPosition: OneDProperty
   readonly zPosition: OneDProperty
-  readonly scale: TwoDProperty | ThreeDProperty
+  readonly scale: Property<TwoDType | ThreeDType>
   readonly orientation: ThreeDProperty
   readonly rotation: OneDProperty
   readonly xRotation: OneDProperty

--- a/AfterEffects/13.1/index.d.ts
+++ b/AfterEffects/13.1/index.d.ts
@@ -1358,12 +1358,12 @@ declare class Layer extends PropertyGroup {
   readonly transform: _TransformGroup
 
   /** Transform shortcuts */
-  readonly anchorPoint: TwoDProperty | ThreeDProperty
-  readonly position: TwoDProperty | ThreeDProperty
+  readonly anchorPoint: Property<TwoDType | ThreeDType>
+  readonly position: Property<TwoDType | ThreeDType>
   readonly xPosition: OneDProperty
   readonly yPosition: OneDProperty
   readonly zPosition: OneDProperty
-  readonly scale: TwoDProperty | ThreeDProperty
+  readonly scale: Property<TwoDType | ThreeDType>
   readonly orientation: ThreeDProperty
   readonly rotation: OneDProperty
   readonly xRotation: OneDProperty
@@ -2356,12 +2356,12 @@ declare class ViewOptions {
  * Properties for Shortcuts
  */
 declare interface _TransformGroup extends PropertyGroup {
-  readonly anchorPoint: TwoDProperty | ThreeDProperty
-  readonly position: TwoDProperty | ThreeDProperty
+  readonly anchorPoint: Property<TwoDType | ThreeDType>
+  readonly position: Property<TwoDType | ThreeDType>
   readonly xPosition: OneDProperty
   readonly yPosition: OneDProperty
   readonly zPosition: OneDProperty
-  readonly scale: TwoDProperty | ThreeDProperty
+  readonly scale: Property<TwoDType | ThreeDType>
   readonly orientation: ThreeDProperty
   readonly rotation: OneDProperty
   readonly xRotation: OneDProperty

--- a/AfterEffects/13.2/index.d.ts
+++ b/AfterEffects/13.2/index.d.ts
@@ -1364,12 +1364,12 @@ declare class Layer extends PropertyGroup {
   readonly transform: _TransformGroup
 
   /** Transform shortcuts */
-  readonly anchorPoint: TwoDProperty | ThreeDProperty
-  readonly position: TwoDProperty | ThreeDProperty
+  readonly anchorPoint: Property<TwoDType | ThreeDType>
+  readonly position: Property<TwoDType | ThreeDType>
   readonly xPosition: OneDProperty
   readonly yPosition: OneDProperty
   readonly zPosition: OneDProperty
-  readonly scale: TwoDProperty | ThreeDProperty
+  readonly scale: Property<TwoDType | ThreeDType>
   readonly orientation: ThreeDProperty
   readonly rotation: OneDProperty
   readonly xRotation: OneDProperty
@@ -2395,12 +2395,12 @@ declare class ViewOptions {
  * Properties for Shortcuts
  */
 declare interface _TransformGroup extends PropertyGroup {
-  readonly anchorPoint: TwoDProperty | ThreeDProperty
-  readonly position: TwoDProperty | ThreeDProperty
+  readonly anchorPoint: Property<TwoDType | ThreeDType>
+  readonly position: Property<TwoDType | ThreeDType>
   readonly xPosition: OneDProperty
   readonly yPosition: OneDProperty
   readonly zPosition: OneDProperty
-  readonly scale: TwoDProperty | ThreeDProperty
+  readonly scale: Property<TwoDType | ThreeDType>
   readonly orientation: ThreeDProperty
   readonly rotation: OneDProperty
   readonly xRotation: OneDProperty

--- a/AfterEffects/13.6/index.d.ts
+++ b/AfterEffects/13.6/index.d.ts
@@ -1369,12 +1369,12 @@ declare class Layer extends PropertyGroup {
   readonly transform: _TransformGroup
 
   /** Transform shortcuts */
-  readonly anchorPoint: TwoDProperty | ThreeDProperty
-  readonly position: TwoDProperty | ThreeDProperty
+  readonly anchorPoint: Property<TwoDType | ThreeDType>
+  readonly position: Property<TwoDType | ThreeDType>
   readonly xPosition: OneDProperty
   readonly yPosition: OneDProperty
   readonly zPosition: OneDProperty
-  readonly scale: TwoDProperty | ThreeDProperty
+  readonly scale: Property<TwoDType | ThreeDType>
   readonly orientation: ThreeDProperty
   readonly rotation: OneDProperty
   readonly xRotation: OneDProperty
@@ -2403,12 +2403,12 @@ declare class ViewOptions {
  * Properties for Shortcuts
  */
 declare interface _TransformGroup extends PropertyGroup {
-  readonly anchorPoint: TwoDProperty | ThreeDProperty
-  readonly position: TwoDProperty | ThreeDProperty
+  readonly anchorPoint: Property<TwoDType | ThreeDType>
+  readonly position: Property<TwoDType | ThreeDType>
   readonly xPosition: OneDProperty
   readonly yPosition: OneDProperty
   readonly zPosition: OneDProperty
-  readonly scale: TwoDProperty | ThreeDProperty
+  readonly scale: Property<TwoDType | ThreeDType>
   readonly orientation: ThreeDProperty
   readonly rotation: OneDProperty
   readonly xRotation: OneDProperty

--- a/AfterEffects/13.8/index.d.ts
+++ b/AfterEffects/13.8/index.d.ts
@@ -1379,12 +1379,12 @@ declare class Layer extends PropertyGroup {
   readonly transform: _TransformGroup
 
   /** Transform shortcuts */
-  readonly anchorPoint: TwoDProperty | ThreeDProperty
-  readonly position: TwoDProperty | ThreeDProperty
+  readonly anchorPoint: Property<TwoDType | ThreeDType>
+  readonly position: Property<TwoDType | ThreeDType>
   readonly xPosition: OneDProperty
   readonly yPosition: OneDProperty
   readonly zPosition: OneDProperty
-  readonly scale: TwoDProperty | ThreeDProperty
+  readonly scale: Property<TwoDType | ThreeDType>
   readonly orientation: ThreeDProperty
   readonly rotation: OneDProperty
   readonly xRotation: OneDProperty
@@ -2416,12 +2416,12 @@ declare class ViewOptions {
  * Properties for Shortcuts
  */
 declare interface _TransformGroup extends PropertyGroup {
-  readonly anchorPoint: TwoDProperty | ThreeDProperty
-  readonly position: TwoDProperty | ThreeDProperty
+  readonly anchorPoint: Property<TwoDType | ThreeDType>
+  readonly position: Property<TwoDType | ThreeDType>
   readonly xPosition: OneDProperty
   readonly yPosition: OneDProperty
   readonly zPosition: OneDProperty
-  readonly scale: TwoDProperty | ThreeDProperty
+  readonly scale: Property<TwoDType | ThreeDType>
   readonly orientation: ThreeDProperty
   readonly rotation: OneDProperty
   readonly xRotation: OneDProperty

--- a/AfterEffects/14.0/index.d.ts
+++ b/AfterEffects/14.0/index.d.ts
@@ -1428,12 +1428,12 @@ declare class Layer extends PropertyGroup {
   readonly transform: _TransformGroup
 
   /** Transform shortcuts */
-  readonly anchorPoint: TwoDProperty | ThreeDProperty
-  readonly position: TwoDProperty | ThreeDProperty
+  readonly anchorPoint: Property<TwoDType | ThreeDType>
+  readonly position: Property<TwoDType | ThreeDType>
   readonly xPosition: OneDProperty
   readonly yPosition: OneDProperty
   readonly zPosition: OneDProperty
-  readonly scale: TwoDProperty | ThreeDProperty
+  readonly scale: Property<TwoDType | ThreeDType>
   readonly orientation: ThreeDProperty
   readonly rotation: OneDProperty
   readonly xRotation: OneDProperty
@@ -2471,12 +2471,12 @@ declare class ViewOptions {
  * Properties for Shortcuts
  */
 declare interface _TransformGroup extends PropertyGroup {
-  readonly anchorPoint: TwoDProperty | ThreeDProperty
-  readonly position: TwoDProperty | ThreeDProperty
+  readonly anchorPoint: Property<TwoDType | ThreeDType>
+  readonly position: Property<TwoDType | ThreeDType>
   readonly xPosition: OneDProperty
   readonly yPosition: OneDProperty
   readonly zPosition: OneDProperty
-  readonly scale: TwoDProperty | ThreeDProperty
+  readonly scale: Property<TwoDType | ThreeDType>
   readonly orientation: ThreeDProperty
   readonly rotation: OneDProperty
   readonly xRotation: OneDProperty

--- a/AfterEffects/14.2/index.d.ts
+++ b/AfterEffects/14.2/index.d.ts
@@ -1428,12 +1428,12 @@ declare class Layer extends PropertyGroup {
   readonly transform: _TransformGroup
 
   /** Transform shortcuts */
-  readonly anchorPoint: TwoDProperty | ThreeDProperty
-  readonly position: TwoDProperty | ThreeDProperty
+  readonly anchorPoint: Property<TwoDType | ThreeDType>
+  readonly position: Property<TwoDType | ThreeDType>
   readonly xPosition: OneDProperty
   readonly yPosition: OneDProperty
   readonly zPosition: OneDProperty
-  readonly scale: TwoDProperty | ThreeDProperty
+  readonly scale: Property<TwoDType | ThreeDType>
   readonly orientation: ThreeDProperty
   readonly rotation: OneDProperty
   readonly xRotation: OneDProperty
@@ -2519,12 +2519,12 @@ declare class ViewOptions {
  * Properties for Shortcuts
  */
 declare interface _TransformGroup extends PropertyGroup {
-  readonly anchorPoint: TwoDProperty | ThreeDProperty
-  readonly position: TwoDProperty | ThreeDProperty
+  readonly anchorPoint: Property<TwoDType | ThreeDType>
+  readonly position: Property<TwoDType | ThreeDType>
   readonly xPosition: OneDProperty
   readonly yPosition: OneDProperty
   readonly zPosition: OneDProperty
-  readonly scale: TwoDProperty | ThreeDProperty
+  readonly scale: Property<TwoDType | ThreeDType>
   readonly orientation: ThreeDProperty
   readonly rotation: OneDProperty
   readonly xRotation: OneDProperty

--- a/AfterEffects/15.0/index.d.ts
+++ b/AfterEffects/15.0/index.d.ts
@@ -1438,12 +1438,12 @@ declare class Layer extends PropertyGroup {
   readonly transform: _TransformGroup
 
   /** Transform shortcuts */
-  readonly anchorPoint: TwoDProperty | ThreeDProperty
-  readonly position: TwoDProperty | ThreeDProperty
+  readonly anchorPoint: Property<TwoDType | ThreeDType>
+  readonly position: Property<TwoDType | ThreeDType>
   readonly xPosition: OneDProperty
   readonly yPosition: OneDProperty
   readonly zPosition: OneDProperty
-  readonly scale: TwoDProperty | ThreeDProperty
+  readonly scale: Property<TwoDType | ThreeDType>
   readonly orientation: ThreeDProperty
   readonly rotation: OneDProperty
   readonly xRotation: OneDProperty
@@ -2535,12 +2535,12 @@ declare class ViewOptions {
  * Properties for Shortcuts
  */
 declare interface _TransformGroup extends PropertyGroup {
-  readonly anchorPoint: TwoDProperty | ThreeDProperty
-  readonly position: TwoDProperty | ThreeDProperty
+  readonly anchorPoint: Property<TwoDType | ThreeDType>
+  readonly position: Property<TwoDType | ThreeDType>
   readonly xPosition: OneDProperty
   readonly yPosition: OneDProperty
   readonly zPosition: OneDProperty
-  readonly scale: TwoDProperty | ThreeDProperty
+  readonly scale: Property<TwoDType | ThreeDType>
   readonly orientation: ThreeDProperty
   readonly rotation: OneDProperty
   readonly xRotation: OneDProperty

--- a/AfterEffects/16.0/index.d.ts
+++ b/AfterEffects/16.0/index.d.ts
@@ -1442,12 +1442,12 @@ declare class Layer extends PropertyGroup {
   readonly transform: _TransformGroup
 
   /** Transform shortcuts */
-  readonly anchorPoint: TwoDProperty | ThreeDProperty
-  readonly position: TwoDProperty | ThreeDProperty
+  readonly anchorPoint: Property<TwoDType | ThreeDType>
+  readonly position: Property<TwoDType | ThreeDType>
   readonly xPosition: OneDProperty
   readonly yPosition: OneDProperty
   readonly zPosition: OneDProperty
-  readonly scale: TwoDProperty | ThreeDProperty
+  readonly scale: Property<TwoDType | ThreeDType>
   readonly orientation: ThreeDProperty
   readonly rotation: OneDProperty
   readonly xRotation: OneDProperty
@@ -2566,12 +2566,12 @@ declare class ViewOptions {
  * Properties for Shortcuts
  */
 declare interface _TransformGroup extends PropertyGroup {
-  readonly anchorPoint: TwoDProperty | ThreeDProperty
-  readonly position: TwoDProperty | ThreeDProperty
+  readonly anchorPoint: Property<TwoDType | ThreeDType>
+  readonly position: Property<TwoDType | ThreeDType>
   readonly xPosition: OneDProperty
   readonly yPosition: OneDProperty
   readonly zPosition: OneDProperty
-  readonly scale: TwoDProperty | ThreeDProperty
+  readonly scale: Property<TwoDType | ThreeDType>
   readonly orientation: ThreeDProperty
   readonly rotation: OneDProperty
   readonly xRotation: OneDProperty

--- a/AfterEffects/16.1/index.d.ts
+++ b/AfterEffects/16.1/index.d.ts
@@ -1460,12 +1460,12 @@ declare class Layer extends PropertyGroup {
   readonly transform: _TransformGroup
 
   /** Transform shortcuts */
-  readonly anchorPoint: TwoDProperty | ThreeDProperty
-  readonly position: TwoDProperty | ThreeDProperty
+  readonly anchorPoint: Property<TwoDType | ThreeDType>
+  readonly position: Property<TwoDType | ThreeDType>
   readonly xPosition: OneDProperty
   readonly yPosition: OneDProperty
   readonly zPosition: OneDProperty
-  readonly scale: TwoDProperty | ThreeDProperty
+  readonly scale: Property<TwoDType | ThreeDType>
   readonly orientation: ThreeDProperty
   readonly rotation: OneDProperty
   readonly xRotation: OneDProperty
@@ -2599,12 +2599,12 @@ declare class ViewOptions {
  * Properties for Shortcuts
  */
 declare interface _TransformGroup extends PropertyGroup {
-  readonly anchorPoint: TwoDProperty | ThreeDProperty
-  readonly position: TwoDProperty | ThreeDProperty
+  readonly anchorPoint: Property<TwoDType | ThreeDType>
+  readonly position: Property<TwoDType | ThreeDType>
   readonly xPosition: OneDProperty
   readonly yPosition: OneDProperty
   readonly zPosition: OneDProperty
-  readonly scale: TwoDProperty | ThreeDProperty
+  readonly scale: Property<TwoDType | ThreeDType>
   readonly orientation: ThreeDProperty
   readonly rotation: OneDProperty
   readonly xRotation: OneDProperty

--- a/AfterEffects/17.0/index.d.ts
+++ b/AfterEffects/17.0/index.d.ts
@@ -1461,12 +1461,12 @@ declare class Layer extends PropertyGroup {
   readonly transform: _TransformGroup
 
   /** Transform shortcuts */
-  readonly anchorPoint: TwoDProperty | ThreeDProperty
-  readonly position: TwoDProperty | ThreeDProperty
+  readonly anchorPoint: Property<TwoDType | ThreeDType>
+  readonly position: Property<TwoDType | ThreeDType>
   readonly xPosition: OneDProperty
   readonly yPosition: OneDProperty
   readonly zPosition: OneDProperty
-  readonly scale: TwoDProperty | ThreeDProperty
+  readonly scale: Property<TwoDType | ThreeDType>
   readonly orientation: ThreeDProperty
   readonly rotation: OneDProperty
   readonly xRotation: OneDProperty
@@ -2606,12 +2606,12 @@ declare class ViewOptions {
  * Properties for Shortcuts
  */
 declare interface _TransformGroup extends PropertyGroup {
-  readonly anchorPoint: TwoDProperty | ThreeDProperty
-  readonly position: TwoDProperty | ThreeDProperty
+  readonly anchorPoint: Property<TwoDType | ThreeDType>
+  readonly position: Property<TwoDType | ThreeDType>
   readonly xPosition: OneDProperty
   readonly yPosition: OneDProperty
   readonly zPosition: OneDProperty
-  readonly scale: TwoDProperty | ThreeDProperty
+  readonly scale: Property<TwoDType | ThreeDType>
   readonly orientation: ThreeDProperty
   readonly rotation: OneDProperty
   readonly xRotation: OneDProperty

--- a/AfterEffects/17.1/index.d.ts
+++ b/AfterEffects/17.1/index.d.ts
@@ -1464,12 +1464,12 @@ declare class Layer extends PropertyGroup {
   readonly transform: _TransformGroup
 
   /** Transform shortcuts */
-  readonly anchorPoint: TwoDProperty | ThreeDProperty
-  readonly position: TwoDProperty | ThreeDProperty
+  readonly anchorPoint: Property<TwoDType | ThreeDType>
+  readonly position: Property<TwoDType | ThreeDType>
   readonly xPosition: OneDProperty
   readonly yPosition: OneDProperty
   readonly zPosition: OneDProperty
-  readonly scale: TwoDProperty | ThreeDProperty
+  readonly scale: Property<TwoDType | ThreeDType>
   readonly orientation: ThreeDProperty
   readonly rotation: OneDProperty
   readonly xRotation: OneDProperty
@@ -2609,12 +2609,12 @@ declare class ViewOptions {
  * Properties for Shortcuts
  */
 declare interface _TransformGroup extends PropertyGroup {
-  readonly anchorPoint: TwoDProperty | ThreeDProperty
-  readonly position: TwoDProperty | ThreeDProperty
+  readonly anchorPoint: Property<TwoDType | ThreeDType>
+  readonly position: Property<TwoDType | ThreeDType>
   readonly xPosition: OneDProperty
   readonly yPosition: OneDProperty
   readonly zPosition: OneDProperty
-  readonly scale: TwoDProperty | ThreeDProperty
+  readonly scale: Property<TwoDType | ThreeDType>
   readonly orientation: ThreeDProperty
   readonly rotation: OneDProperty
   readonly xRotation: OneDProperty

--- a/AfterEffects/18.0/index.d.ts
+++ b/AfterEffects/18.0/index.d.ts
@@ -1476,12 +1476,12 @@ declare class Layer extends PropertyGroup {
   readonly transform: _TransformGroup
 
   /** Transform shortcuts */
-  readonly anchorPoint: TwoDProperty | ThreeDProperty
-  readonly position: TwoDProperty | ThreeDProperty
+  readonly anchorPoint: Property<TwoDType | ThreeDType>
+  readonly position: Property<TwoDType | ThreeDType>
   readonly xPosition: OneDProperty
   readonly yPosition: OneDProperty
   readonly zPosition: OneDProperty
-  readonly scale: TwoDProperty | ThreeDProperty
+  readonly scale: Property<TwoDType | ThreeDType>
   readonly orientation: ThreeDProperty
   readonly rotation: OneDProperty
   readonly xRotation: OneDProperty
@@ -2630,12 +2630,12 @@ declare class ViewOptions {
  * Properties for Shortcuts
  */
 declare interface _TransformGroup extends PropertyGroup {
-  readonly anchorPoint: TwoDProperty | ThreeDProperty
-  readonly position: TwoDProperty | ThreeDProperty
+  readonly anchorPoint: Property<TwoDType | ThreeDType>
+  readonly position: Property<TwoDType | ThreeDType>
   readonly xPosition: OneDProperty
   readonly yPosition: OneDProperty
   readonly zPosition: OneDProperty
-  readonly scale: TwoDProperty | ThreeDProperty
+  readonly scale: Property<TwoDType | ThreeDType>
   readonly orientation: ThreeDProperty
   readonly rotation: OneDProperty
   readonly xRotation: OneDProperty

--- a/AfterEffects/8.0/index.d.ts
+++ b/AfterEffects/8.0/index.d.ts
@@ -1244,12 +1244,12 @@ declare class Layer extends PropertyGroup {
   readonly transform: _TransformGroup
 
   /** Transform shortcuts */
-  readonly anchorPoint: TwoDProperty | ThreeDProperty
-  readonly position: TwoDProperty | ThreeDProperty
+  readonly anchorPoint: Property<TwoDType | ThreeDType>
+  readonly position: Property<TwoDType | ThreeDType>
   readonly xPosition: OneDProperty
   readonly yPosition: OneDProperty
   readonly zPosition: OneDProperty
-  readonly scale: TwoDProperty | ThreeDProperty
+  readonly scale: Property<TwoDType | ThreeDType>
   readonly orientation: ThreeDProperty
   readonly rotation: OneDProperty
   readonly xRotation: OneDProperty
@@ -2031,12 +2031,12 @@ declare class TextLayer extends AVLayer {
  * Properties for Shortcuts
  */
 declare interface _TransformGroup extends PropertyGroup {
-  readonly anchorPoint: TwoDProperty | ThreeDProperty
-  readonly position: TwoDProperty | ThreeDProperty
+  readonly anchorPoint: Property<TwoDType | ThreeDType>
+  readonly position: Property<TwoDType | ThreeDType>
   readonly xPosition: OneDProperty
   readonly yPosition: OneDProperty
   readonly zPosition: OneDProperty
-  readonly scale: TwoDProperty | ThreeDProperty
+  readonly scale: Property<TwoDType | ThreeDType>
   readonly orientation: ThreeDProperty
   readonly rotation: OneDProperty
   readonly xRotation: OneDProperty

--- a/AfterEffects/9.0/index.d.ts
+++ b/AfterEffects/9.0/index.d.ts
@@ -1260,12 +1260,12 @@ declare class Layer extends PropertyGroup {
   readonly transform: _TransformGroup
 
   /** Transform shortcuts */
-  readonly anchorPoint: TwoDProperty | ThreeDProperty
-  readonly position: TwoDProperty | ThreeDProperty
+  readonly anchorPoint: Property<TwoDType | ThreeDType>
+  readonly position: Property<TwoDType | ThreeDType>
   readonly xPosition: OneDProperty
   readonly yPosition: OneDProperty
   readonly zPosition: OneDProperty
-  readonly scale: TwoDProperty | ThreeDProperty
+  readonly scale: Property<TwoDType | ThreeDType>
   readonly orientation: ThreeDProperty
   readonly rotation: OneDProperty
   readonly xRotation: OneDProperty
@@ -2113,12 +2113,12 @@ declare class TextLayer extends AVLayer {
  * Properties for Shortcuts
  */
 declare interface _TransformGroup extends PropertyGroup {
-  readonly anchorPoint: TwoDProperty | ThreeDProperty
-  readonly position: TwoDProperty | ThreeDProperty
+  readonly anchorPoint: Property<TwoDType | ThreeDType>
+  readonly position: Property<TwoDType | ThreeDType>
   readonly xPosition: OneDProperty
   readonly yPosition: OneDProperty
   readonly zPosition: OneDProperty
-  readonly scale: TwoDProperty | ThreeDProperty
+  readonly scale: Property<TwoDType | ThreeDType>
   readonly orientation: ThreeDProperty
   readonly rotation: OneDProperty
   readonly xRotation: OneDProperty


### PR DESCRIPTION
Using `Property<TwoDType | ThreeDType>` instead of `TwoDProperty | ThreeDProperty`, because some of the latter's properties types are `nerver`.

