### PR TITLE
Update AfterEffects 22.0 Layer class

### DIFF
--- a/AfterEffects/22.0/index.d.ts
+++ b/AfterEffects/22.0/index.d.ts
@@ -1381,6 +1381,9 @@ declare class KeyframeEase {
 }
 
 declare class Layer extends PropertyGroup {
+  /** The unique and persistent identification number. */
+  readonly id: number
+
   /** The index position of the layer. */
   readonly index: number
 


### PR DESCRIPTION
This PR extends the Layer class with unique and persistent identification number. 

Specs: https://ae-scripting.docsforadobe.dev/layers/layer.html#layer-id
Tested on AE 2022 (22.6).