### PR TITLE
Fix: `prompt()` can return null

### DIFF
--- a/shared/ScriptUI.d.ts
+++ b/shared/ScriptUI.d.ts
@@ -363,7 +363,7 @@ declare class Window extends _Control {
    * @param default_ The initial value to be displayed in the text edit field.
    * @param title A string to appear as the title of the dialog. In Windows, this appears in the window’s frame; in Mac OS it appears above the message. The default title string is "Script Prompt".
    */
-  static prompt(prompt: string, default_?: string, title?: string): string
+  static prompt(prompt: string, default_?: string, title?: string): string | null
 
   /**
    * Removes the specified child control from this window’s children array.

--- a/shared/global.d.ts
+++ b/shared/global.d.ts
@@ -129,7 +129,7 @@ declare function parseInt(text: string, base?: number): number
  * @param default_ The default text to preset the edit field with
  * @param title The title of the dialog;
  */
-declare function prompt(prompt: string, default_?: string, title?: string): string
+declare function prompt(prompt: string, default_?: string, title?: string): string | null
 
 /**
  * Defines the default XML namespace.


### PR DESCRIPTION
The global `prompt()` function can return `null` as described in the [documentation](https://extendscript.docsforadobe.dev/extendscript-tools-features/user-notification-dialogs.html#global-prompt-function).

Quote:

> Returns the value of the text edit field if the user clicked OK, null if the user clicked Cancel.