### PR TITLE
Fix: ComponentParamCollection needs numItems and length property

### DIFF
--- a/Premiere/15.0/index.d.ts
+++ b/Premiere/15.0/index.d.ts
@@ -1921,6 +1921,16 @@ declare class Encoder {
  *
  */
 declare class ComponentParamCollection {
+  /**Number of items
+   *
+   */
+  readonly numItems: number
+  /**Number of items
+   *
+   */
+  readonly length: number;
+
+
   bind(eventName: string, function_: any): void
   clearProperty(propertyKey: string): void
   doesPropertyExist(propertyKey: string): boolean


### PR DESCRIPTION
fixes #112 

Observed this issue when trying to iterate over the properties of a component. I noticed I could access properties through indexing but when trying to access the length of the collection, we received a linting error but the code works at run time. 
`Property 'numItems' does not exist on type 'ComponentParamCollection'.ts(2339)`

```typescript
const seq = app.project.activeSequence;
  const tracks = seq.getSelection();
  for (let track of tracks) {
      let components: ComponentCollection = track.components;
      for (let i = 0; i < components.numItems; i++) {
          const comp = components[i];
          comp.properties[0]
          for (let j = 0; j < comp.properties.numItems; j++) { // !THE ISSUE
              // numItems and length is not defined in ComponentPropertiesCollection, but this exists
              
```
I noticed that the `numItems` and `length` properties were used in the codebase but weren't defined like other Collection types

all this fix does is set the properties `length` and `numItems`
